### PR TITLE
Update listenerFunctions.js

### DIFF
--- a/GDSA.js
+++ b/GDSA.js
@@ -158,7 +158,16 @@ function registerSystemSettings() {
     })
 }
 
-function adjustRessource(target, value, type) { target.setStatData(type, value) };
+function adjustRessource(target, value, type) { 
+    
+    if (target instanceof TokenDocument) {
+        target = target.actor;
+    } else if (target instanceof Object) {
+        target = canvas.tokens.get(target._id).document.actor;
+    }
+
+    target.setStatData(type, value);
+};
 
 function sendToMemory(key, object) {
 

--- a/module/listenerFunctions.js
+++ b/module/listenerFunctions.js
@@ -323,9 +323,12 @@ export async function onSpellRoll(data, event) {
         if (modis.length > 0) isSpez = true;
         
         let vars = item.system.vars;
-        let spzVars = vars.filter(function(mod) {return mod.name.includes(value)})[0];
-        if (spzVars != null) if (checkOptions.variants[spzVars.id]) isSpez = true;
-    
+
+        if (vars != null)
+        {
+            let spzVars = vars.filter(function(mod) {return mod.name.includes(value)})[0];
+            if (spzVars != null) if (checkOptions.variants[spzVars.id]) isSpez = true;
+        }    
     }
 
     if (isSpez) spellValue = parseInt(spellValue) + 2;

--- a/module/listenerFunctions.js
+++ b/module/listenerFunctions.js
@@ -2243,7 +2243,7 @@ export async function onAttackRoll(data, event) {
     
     dmg.message.setFlag('gdsa', 'isCollapsable', true);
 
-    GDSA.socket.executeAsGM("adjustRessource", targetToken.actor, newHP, "LeP");
+    GDSA.socket.executeAsGM("adjustRessource", targetToken, newHP, "LeP");
 
     if(isPartofCombat && newHP <= 0) {
 


### PR DESCRIPTION
Quickfix: Prevent error in spell casting because of missing spell variants (variable not initialized)